### PR TITLE
ci: point hygiene workflows at actionsforge

### DIFF
--- a/.github/workflows/commitmsg-conform.yml
+++ b/.github/workflows/commitmsg-conform.yml
@@ -1,11 +1,14 @@
-name: commit-message-conformance
+name: Commit Message Conformance
+
 on:
   pull_request: {}
+
 permissions:
   statuses: write
   checks: write
   contents: read
   pull-requests: read
+
 jobs:
   commitmsg-conform:
-    uses: stacksmiths/actions/.github/workflows/commitmsg-conform.yml@main
+    uses: actionsforge/actions/.github/workflows/commitmsg-conform.yml@main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,11 +1,14 @@
-name: markdown-lint
+name: Markdown Lint
+
 on:
   pull_request: {}
+
 permissions:
   statuses: write
   checks: write
   contents: read
   pull-requests: read
+
 jobs:
   markdown-lint:
-    uses: stacksmiths/actions/.github/workflows/markdown-lint.yml@main
+    uses: actionsforge/actions/.github/workflows/markdown-lint.yml@main


### PR DESCRIPTION
## Summary
- Point `markdown-lint.yml` / `commitmsg-conform.yml` at `actionsforge/actions`
- Align workflow display names with the forge template

## Test plan
- [ ] PR checks run Markdown Lint and Commit Message Conformance via actionsforge

Closes #7